### PR TITLE
Added query timeouts

### DIFF
--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -27,12 +27,15 @@
     node :: #node{}
 }).
 
+-define(DEFAULT_QUERY_TIMEOUT, 5000).
+
 -define(OL_TRANSACTION_TTL, 16).
 -define(REDIS_CLUSTER_HASH_SLOTS, 16384).
 
 % Retries will take 5, 25, 125, 625, 3125, 15625 miliseconds
 -define(QUERY_LIMIT, 7).
 -define(EXPONENTIAL_BACKOFF_BASE, 5).
+
 
 -define(CRCDEF, <<16#00,16#00,16#10,16#21,16#20,16#42,16#30,16#63,
 16#40,16#84,16#50,16#a5,16#60,16#c6,16#70,16#e7,

--- a/src/eredis_cluster_pool_worker.erl
+++ b/src/eredis_cluster_pool_worker.erl
@@ -4,7 +4,7 @@
 
 %% API.
 -export([start_link/1]).
--export([query/2]).
+-export([query/2, query/3]).
 
 %% gen_server.
 -export([init/1]).
@@ -37,6 +37,9 @@ init(Args) ->
     end,
 
     {ok, #state{conn=Conn}}.
+
+query(Worker, Commands, Timeout) ->
+    gen_server:call(Worker, {'query', Commands}, Timeout).
 
 query(Worker, Commands) ->
     gen_server:call(Worker, {'query', Commands}).


### PR DESCRIPTION
We need to be able to control timeouts from the caller side not simply use the default 5000ms gen_server call.